### PR TITLE
fix grid_coords in get_grid_coords

### DIFF
--- a/lib/networks/latent_xyzc.py
+++ b/lib/networks/latent_xyzc.py
@@ -54,7 +54,7 @@ class Network(nn.Module):
         dhw = dhw / torch.tensor(cfg.voxel_size).to(dhw)
         # convert the voxel coordinate to [-1, 1]
         out_sh = torch.tensor(sp_input['out_sh']).to(dhw)
-        dhw = dhw / out_sh * 2 - 1
+        dhw = dhw / (out_sh - 1) * 2 - 1
         # convert dhw to whd, since the occupancy is indexed by dhw
         grid_coords = dhw[..., [2, 1, 0]]
         return grid_coords


### PR DESCRIPTION
After reviewing the source code of the F.grid_sample method in PyTorch, I believe that the code on line 57 should be modified from `dhw = dhw / out_sh * 2 - 1` to `dhw = dhw / (out_sh-1) * 2 - 1`. The original computation can cause a slight offset in the coordinates of pts queried in F.grid_sample.

For more information about the source code, see https://github.com/pytorch/pytorch/blob/f064c5aa33483061a48994608d890b968ae53fb5/aten/src/THNN/generic/SpatialGridSamplerBilinear.c#L66-L71

I also conducted some experiments to verify whether it is necessary to divide by (shape-1) during the normalization process, and the experimental results showed that my idea was correct. You can try replacing samplepoints with vertices to query the unconvolved sparse space for verification, and I am willing to provide my validation code.